### PR TITLE
[getdeps] fetch dependencies in parallel on github CI

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -24,56 +24,33 @@ jobs:
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive fizz
     - name: Install packaging system deps
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
-    - name: Fetch ninja
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
-    - name: Fetch cmake
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
-    - name: Fetch boost
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
-    - name: Fetch double-conversion
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
-    - name: Fetch fast_float
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
-    - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
-    - name: Fetch gflags
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
-    - name: Fetch glog
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
-    - name: Fetch googletest
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
-    - name: Fetch libdwarf
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
-    - name: Fetch libevent
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
-    - name: Fetch lz4
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
-    - name: Fetch snappy
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
-    - name: Fetch zstd
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
-    - name: Fetch openssl
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
-    - name: Fetch liboqs
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
-    - name: Fetch zlib
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
-    - name: Fetch autoconf
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
-    - name: Fetch automake
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
-    - name: Fetch libtool
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
-    - name: Fetch libsodium
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
-    - name: Fetch libiberty
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libiberty
-    - name: Fetch libunwind
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libunwind
-    - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
-    - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
+    - name: Fetch dependencies
+      run: >
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4 &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libiberty &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libunwind &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Build ninja
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -20,52 +20,31 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install system deps
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive fizz
-    - name: Fetch ninja
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
-    - name: Fetch cmake
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
-    - name: Fetch boost
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
-    - name: Fetch double-conversion
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
-    - name: Fetch fast_float
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
-    - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
-    - name: Fetch gflags
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
-    - name: Fetch glog
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
-    - name: Fetch googletest
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
-    - name: Fetch libdwarf
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
-    - name: Fetch lz4
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
-    - name: Fetch openssl
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
-    - name: Fetch snappy
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
-    - name: Fetch zstd
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
-    - name: Fetch liboqs
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
-    - name: Fetch zlib
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
-    - name: Fetch libevent
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
-    - name: Fetch autoconf
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
-    - name: Fetch automake
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
-    - name: Fetch libtool
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
-    - name: Fetch libsodium
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
-    - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
-    - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
+    - name: Fetch dependencies
+      run: >
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4 &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz &&
+        python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Build ninja
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -21,50 +21,36 @@ jobs:
       run: "echo BOOST_ROOT=%BOOST_ROOT_1_83_0% >> %GITHUB_ENV%"
       shell: cmd
     - name: Fix Git config
-      run: git config --system core.longpaths true
-    - name: Disable autocrlf
-      run: git config --system core.autocrlf false
+      run: >
+        git config --system core.longpaths true &&
+        git config --system core.autocrlf false &&
+        git config --system core.symlinks true
+      shell: cmd
     - uses: actions/checkout@v4
-    - name: Fetch libsodium
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests libsodium
-    - name: Fetch ninja
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests ninja
-    - name: Fetch cmake
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests cmake
-    - name: Fetch boost
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests boost
-    - name: Fetch double-conversion
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
-    - name: Fetch fast_float
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests fast_float
-    - name: Fetch fmt
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests fmt
-    - name: Fetch gflags
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests gflags
-    - name: Fetch glog
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests glog
-    - name: Fetch googletest
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests googletest
-    - name: Fetch libdwarf
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests libdwarf
-    - name: Fetch lz4
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests lz4
-    - name: Fetch snappy
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests snappy
-    - name: Fetch zlib
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests zlib
-    - name: Fetch zstd
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests zstd
-    - name: Fetch perl
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests perl
-    - name: Fetch openssl
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests openssl
-    - name: Fetch libevent
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests libevent
-    - name: Fetch folly
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests folly
-    - name: Fetch liboqs
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests liboqs
+    - name: Fetch dependencies
+      run: >
+        python build/fbcode_builder/getdeps.py fetch --no-tests libsodium &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests ninja &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests cmake &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests boost &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests double-conversion &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests fast_float &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests fmt &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests gflags &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests glog &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests googletest &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests libdwarf &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests lz4 &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests snappy &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests zlib &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests zstd &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests jom &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests perl &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests openssl &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests libevent &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests folly &&
+        python build/fbcode_builder/getdeps.py fetch --no-tests liboqs
+      shell: cmd
     - name: Build libsodium
       run: python build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build ninja
@@ -95,6 +81,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests zlib
     - name: Build zstd
       run: python build/fbcode_builder/getdeps.py build --no-tests zstd
+    - name: Build jom
+      run: python build/fbcode_builder/getdeps.py build --no-tests jom
     - name: Build perl
       run: python build/fbcode_builder/getdeps.py build --no-tests perl
     - name: Build openssl


### PR DESCRIPTION
Summary:

Dependency fetches of .tar.gz/.zip/git don't need to wait for each other.  Github actions doesn't have parallel steps so run them in parallel using && sh/cmd.exe operator.

Test Plan:

regenerate github actions with:
```
./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions  --src-dir=. --output-dir=.github/workflows fizz
```

run github CI